### PR TITLE
Tag model を追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,7 @@
 class Article < ApplicationRecord
   belongs_to :user
+  has_many :tag_articles, dependent: :destroy
+  has_many :tags, through: :tag_articles
 
   validates :title, presence: true
   validates :content, presence: true

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,6 @@
+class Tag < ApplicationRecord
+  has_many :tag_articles, dependent: :destroy
+  has_many :articles, through: :tag_articles
+
+  validates :name, presence: true
+end

--- a/app/models/tag_article.rb
+++ b/app/models/tag_article.rb
@@ -1,0 +1,4 @@
+class TagArticle < ApplicationRecord
+  belongs_to :article
+  belongs_to :tag
+end

--- a/db/migrate/20241201114033_create_tags.rb
+++ b/db/migrate/20241201114033_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241201142515_create_tag_articles.rb
+++ b/db/migrate/20241201142515_create_tag_articles.rb
@@ -1,0 +1,10 @@
+class CreateTagArticles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tag_articles do |t|
+      t.references :article, foreign_key: true
+      t.references :tag, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_11_14_140418) do
+ActiveRecord::Schema.define(version: 2024_12_01_142515) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,21 @@ ActiveRecord::Schema.define(version: 2024_11_14_140418) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
     t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "tag_articles", force: :cascade do |t|
+    t.bigint "article_id"
+    t.bigint "tag_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_tag_articles_on_article_id"
+    t.index ["tag_id"], name: "index_tag_articles_on_tag_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -37,4 +52,6 @@ ActiveRecord::Schema.define(version: 2024_11_14_140418) do
   end
 
   add_foreign_key "articles", "users"
+  add_foreign_key "tag_articles", "articles"
+  add_foreign_key "tag_articles", "tags"
 end


### PR DESCRIPTION
## 概要
- Tag model を追加
- Tag_Article model を追加
- データベースにマイグレーションを実行
- 記事とタグのアソシエーションを追加